### PR TITLE
Add single author spider and crawl command

### DIFF
--- a/GoodreadsScraper/spiders/single_author_spider.py
+++ b/GoodreadsScraper/spiders/single_author_spider.py
@@ -6,7 +6,7 @@ from .book_spider import BookSpider
 
 
 class SingleAuthorSpider(scrapy.Spider):
-    """Extract and crawl URLs of books from one of the "My Books" shelf for a user
+    """Extract and crawl URLs of books by a specific author
 
         This subsequently passes on the URLs to BookSpider.
         Consequently, this spider also yields BookItem's and AuthorItem's.

--- a/GoodreadsScraper/spiders/single_author_spider.py
+++ b/GoodreadsScraper/spiders/single_author_spider.py
@@ -1,0 +1,35 @@
+"""Spider to extract URL's of books from a single author"""
+
+import scrapy
+from scrapy import signals
+from .book_spider import BookSpider
+
+
+class SingleAuthorSpider(scrapy.Spider):
+    """Extract and crawl URLs of books from one of the "My Books" shelf for a user
+
+        This subsequently passes on the URLs to BookSpider.
+        Consequently, this spider also yields BookItem's and AuthorItem's.
+    """
+    name = "single-author"
+
+    def _set_crawler(self, crawler):
+        super()._set_crawler(crawler)
+        crawler.signals.connect(self.item_scraped_callback,
+                                signal=signals.item_scraped)
+
+    def __init__(self, author_id, item_scraped_callback=None):
+        super().__init__()
+        self.book_spider = BookSpider()
+        self.item_scraped_callback = item_scraped_callback
+        self.start_urls = [f"https://www.goodreads.com/author/show/{author_id}", f"https://www.goodreads.com/author/list/{author_id}"]
+
+    def parse(self, response):
+        book_urls = response.css("a.bookTitle::attr(href)").extract()
+
+        for book_url in book_urls:
+            yield response.follow(book_url, callback=self.book_spider.parse)
+
+        next_page = response.css('a.next_page').attrib['href']
+        if next_page is not None:
+            yield response.follow(next_page, callback=self.parse)

--- a/crawl.py
+++ b/crawl.py
@@ -172,14 +172,14 @@ def my_books(ctx, user_id: str, shelf: str, output_file_suffix: str):
               type=str)
 @click.pass_context
 def single_author(ctx, author_id: str, output_file_suffix: str):
-    """Crawl shelves from the "My Books" tab for a user."""
+    """Crawl books and author info for all books by a specific author."""
     if not output_file_suffix:
         output_file_suffix = author_id
     click.echo(f"Crawling Goodreads author profile {author_id}")
 
-    # On "My Books", each page of has about ~30 books
+    # On the author's page, each page shows about ~30 books
     # The last page may have less
-    # However, we don't know how many total books there could be on a shelf
+    # However, we don't know how many distinct works this author has
     # So until we can figure it out, show an infinite spinner
     progress_updater = ProgressUpdater(infinite=True)
 


### PR DESCRIPTION
This PR adds a method to `crawl.py` to scrape the books of a single author.

Example: `python -m crawl single-author --author_id 19520462.Arlan_Hamilton`

It is based on the scraper for a shelf, so it will download all relevant books and author information. 